### PR TITLE
Flush matnwb tarball before untarring

### DIFF
--- a/code/src/healthstatus/__main__.py
+++ b/code/src/healthstatus/__main__.py
@@ -172,6 +172,7 @@ def install_matnwb() -> str:
                 r.raise_for_status()
                 for chunk in r.iter_content(65535):
                     fp.write(chunk)
+            fp.flush()
             subprocess.run(
                 [
                     "tar",


### PR DESCRIPTION
While testing #28, I kept running into intermittent errors with `tar` complaining about an early EOF.  This appears to fix the problem.