### PR TITLE
Add MATNWB_SAVEDIR also into MATLABPATH

### DIFF
--- a/code/src/healthstatus/checker.py
+++ b/code/src/healthstatus/checker.py
@@ -82,7 +82,7 @@ async def matnwb_nwbRead(asset: Asset) -> TestResult:
                 f" {MATNWB_SAVEDIR!r})"
             ),
         ],
-        env={"MATLABPATH": str(MATNWB_INSTALL_DIR)},
+        env={"MATLABPATH": f"{MATNWB_INSTALL_DIR}:{MATNWB_SAVEDIR}"},
     )
 
 


### PR DESCRIPTION
apparently it should be included to be able to find those classes.

Ref: https://github.com/NeurodataWithoutBorders/matnwb/issues/481#issuecomment-1414200403