### PR TITLE
ENH: dereference symlinks while running file

### DIFF
--- a/code/src/healthstatus/checker.py
+++ b/code/src/healthstatus/checker.py
@@ -121,10 +121,10 @@ class Untested:
 
     async def run(self) -> UntestedDetails:
         size = getsize(self.asset.filepath)
-        r = await anyio.run_process(["file", "--brief", str(self.asset.filepath)])
+        r = await anyio.run_process(["file", "--brief", "-L", str(self.asset.filepath)])
         file_type = r.stdout.decode("utf-8").strip()
         r = await anyio.run_process(
-            ["file", "--brief", "--mime-type", str(self.asset.filepath)]
+            ["file", "--brief", "--mime-type", "-L", str(self.asset.filepath)]
         )
         mime_type = r.stdout.decode("utf-8").strip()
         log.info(


### PR DESCRIPTION
Otherwise we get not that useful reported for any annexed file.