### PR TITLE
RF: unify into dandisets-healthstatus on CLI and references/name

### DIFF
--- a/code/setup.cfg
+++ b/code/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = dandiset-healthstatus
+name = dandisets-healthstatus
 version = 0.0.0
 description = Run healthchecks on assets in Dandi Archive
 long_description = file:README.rst
@@ -7,10 +7,10 @@ long_description_content_type = text/x-rst
 author = DANDI Developers
 author_email = team@dandiarchive.org
 maintainer = John Thorvald Wodder II
-maintainer_email = dandiset-healthstatus@varonathe.org
+maintainer_email = dandisets-healthstatus@varonathe.org
 license = MIT
 license_files = LICENSE
-url = https://github.com/dandi/dandiset-healthstatus
+url = https://github.com/dandi/dandisets-healthstatus
 
 [options]
 packages = find_namespace:

--- a/code/setup.cfg
+++ b/code/setup.cfg
@@ -33,7 +33,7 @@ where = src
 
 [options.entry_points]
 console_scripts =
-    healthstatus = healthstatus.__main__:main
+    dandisets-healthstatus = healthstatus.__main__:main
 
 [mypy]
 allow_incomplete_defs = False

--- a/code/src/healthstatus/__init__.py
+++ b/code/src/healthstatus/__init__.py
@@ -1,5 +1,5 @@
 """
 Run healthchecks on assets in Dandi Archive
 
-Visit <https://github.com/dandi/dandiset-healthstatus> for more information.
+Visit <https://github.com/dandi/dandisets-healthstatus> for more information.
 """

--- a/run.sh
+++ b/run.sh
@@ -18,8 +18,8 @@ cd "$(dirname "$0")"
 pip install ./code
 #pip install 'git+https://github.com/fsspec/filesystem_spec'
 pip install 'git+https://github.com/jwodder/filesystem_spec@rlock-cache'
-healthstatus check -d "$DANDISETS_PATH" -m "$MOUNT_PATH" -J 10 "$@"
-healthstatus report
+dandisets-healthstatus check -d "$DANDISETS_PATH" -m "$MOUNT_PATH" -J 10 "$@"
+dandisets-healthstatus report
 
 # TODO: Uncomment this block when setting up the cronjob:
 #git add .


### PR DESCRIPTION
I am ok with keeping python package just healthstatus since unlikely to be ever pushed to pypi etc.