### PR TITLE
Test against Python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
         toxenv: [py]
         include:
           - python-version: '3.8'


### PR DESCRIPTION
Currently blocked because datalad-fuse requires aiohttp, which doesn't yet support Python 3.12.