### PR TITLE
Add benchmarking of various mounting strategies

### DIFF
--- a/WEBDAV.md
+++ b/WEBDAV.md
@@ -36,6 +36,9 @@ davfs2
     username ALL=(ALL:ALL) NOPASSWD: /usr/bin/umount /tmp/dandisets-fuse
     ```
 
+- Ensure that the `dandidav` instance at webdav.dandiarchive.org is being run
+  with the `--prefer-s3-redirects` option
+
 
 <!--
 webdavfs

--- a/WEBDAV.md
+++ b/WEBDAV.md
@@ -9,13 +9,13 @@ davfs2
   Debian 12 (bookworm).
 
 - Create a directory to use as the mount point; `tools/bench.sh` uses
-  `/tmp/dandisets-fuse` by default, and this path will be used throughout the
-  following instructions.
+  `/mnt/backup/dandi/dandisets-healthstatus/dandisets-fuse` by default, and
+  this path will be used throughout the following instructions.
 
 - Add the following to `/etc/davfs2/davfs2.conf`:
 
     ```
-    [/tmp/dandisets-fuse]
+    [/mnt/backup/dandi/dandisets-healthstatus/dandisets-fuse]
     ask_auth 0
     follow_redirect 1
     ```
@@ -24,16 +24,16 @@ davfs2
   the following commands with `sudo` without entering a password:
 
     ```
-    mount -t davfs https://webdav.dandiarchive.org /tmp/dandisets-fuse
-    umount /tmp/dandisets-fuse
+    mount -t davfs https://webdav.dandiarchive.org /mnt/backup/dandi/dandisets-healthstatus/dandisets-fuse
+    umount /mnt/backup/dandi/dandisets-healthstatus/dandisets-fuse
     ```
 
   This can be done by adding the following lines to `/etc/sudoers`, where
   `username` is replaced by the name of the user account:
 
     ```
-    username ALL=(ALL:ALL) NOPASSWD: /usr/bin/mount -t davfs https\://webdav.dandiarchive.org /tmp/dandisets-fuse
-    username ALL=(ALL:ALL) NOPASSWD: /usr/bin/umount /tmp/dandisets-fuse
+    username ALL=(ALL:ALL) NOPASSWD: /usr/bin/mount -t davfs https\://webdav.dandiarchive.org /mnt/backup/dandi/dandisets-healthstatus/dandisets-fuse
+    username ALL=(ALL:ALL) NOPASSWD: /usr/bin/umount /mnt/backup/dandi/dandisets-healthstatus/dandisets-fuse
     ```
 
 - Ensure that the `dandidav` instance at webdav.dandiarchive.org is being run
@@ -49,22 +49,22 @@ webdavfs
   it.
 
 - Create a directory to use as the mount point; `tools/bench.sh` uses
-  `/tmp/dandisets-fuse` by default, and this path will be used throughout the
-  following instructions.
+  `/mnt/backup/dandi/dandisets-healthstatus/dandisets-fuse` by default, and
+  this path will be used throughout the following instructions.
 
 - Grant the user who will be running `dandisets-healthstatus` permission to run
   the following commands with `sudo` without entering a password:
 
     ```
-    mount -t webdavfs -o allow_other https://webdav.dandiarchive.org /tmp/dandisets-fuse
-    umount /tmp/dandisets-fuse
+    mount -t webdavfs -o allow_other https://webdav.dandiarchive.org /mnt/backup/dandi/dandisets-healthstatus/dandisets-fuse
+    umount /mnt/backup/dandi/dandisets-healthstatus/dandisets-fuse
     ```
 
   This can be done by adding the following lines to `/etc/sudoers`, where
   `username` is replaced by the name of the user account:
 
     ```
-    username ALL=(ALL:ALL) NOPASSWD: /usr/bin/mount -t webdavfs -o allow_other https\://webdav.dandiarchive.org /tmp/dandisets-fuse
-    username ALL=(ALL:ALL) NOPASSWD: /usr/bin/umount /tmp/dandisets-fuse
+    username ALL=(ALL:ALL) NOPASSWD: /usr/bin/mount -t webdavfs -o allow_other https\://webdav.dandiarchive.org /mnt/backup/dandi/dandisets-healthstatus/dandisets-fuse
+    username ALL=(ALL:ALL) NOPASSWD: /usr/bin/umount /mnt/backup/dandi/dandisets-healthstatus/dandisets-fuse
     ```
 -->

--- a/WEBDAV.md
+++ b/WEBDAV.md
@@ -1,0 +1,67 @@
+Required Setup for WebDAV Mounts
+================================
+
+davfs2
+------
+
+- Install [davfs2](https://savannah.nongnu.org/projects/davfs2/).  This code
+  was initially tested against davfs2, version 1.6.1-1, installed via APT on
+  Debian 12 (bookworm).
+
+- Create a directory to use as the mount point; `tools/bench.sh` uses
+  `/tmp/dandisets-fuse` by default, and this path will be used throughout the
+  following instructions.
+
+- Add the following to `/etc/davfs2/davfs2.conf`:
+
+    ```
+    [/tmp/dandisets-fuse]
+    ask_auth 0
+    follow_redirect 1
+    ```
+
+- Grant the user who will be running `dandisets-healthstatus` permission to run
+  the following commands with `sudo` without entering a password:
+
+    ```
+    mount -t davfs https://webdav.dandiarchive.org /tmp/dandisets-fuse
+    umount /tmp/dandisets-fuse
+    ```
+
+  This can be done by adding the following lines to `/etc/sudoers`, where
+  `username` is replaced by the name of the user account:
+
+    ```
+    username ALL=(ALL:ALL) NOPASSWD: /usr/bin/mount -t davfs https\://webdav.dandiarchive.org /tmp/dandisets-fuse
+    username ALL=(ALL:ALL) NOPASSWD: /usr/bin/umount /tmp/dandisets-fuse
+    ```
+
+
+<!--
+webdavfs
+--------
+
+- Install [webdavfs](https://github.com/miquels/webdavfs).  The
+  `mount.webdavfs` binary must be installed in `/sbin` so that `mount` can find
+  it.
+
+- Create a directory to use as the mount point; `tools/bench.sh` uses
+  `/tmp/dandisets-fuse` by default, and this path will be used throughout the
+  following instructions.
+
+- Grant the user who will be running `dandisets-healthstatus` permission to run
+  the following commands with `sudo` without entering a password:
+
+    ```
+    mount -t webdavfs -o allow_other https://webdav.dandiarchive.org /tmp/dandisets-fuse
+    umount /tmp/dandisets-fuse
+    ```
+
+  This can be done by adding the following lines to `/etc/sudoers`, where
+  `username` is replaced by the name of the user account:
+
+    ```
+    username ALL=(ALL:ALL) NOPASSWD: /usr/bin/mount -t webdavfs -o allow_other https\://webdav.dandiarchive.org /tmp/dandisets-fuse
+    username ALL=(ALL:ALL) NOPASSWD: /usr/bin/umount /tmp/dandisets-fuse
+    ```
+-->

--- a/code/setup.cfg
+++ b/code/setup.cfg
@@ -33,6 +33,12 @@ install_requires =
     requests ~= 2.20
 
 [options.extras_require]
+all =
+    %(dandi)s
+    %(dandidav)s
+dandi =
+    # Needed for timing `dandi ls` runs
+    dandi
 dandidav =
     dandidav @ git+https://github.com/dandi/dandi-webdav
 

--- a/code/setup.cfg
+++ b/code/setup.cfg
@@ -33,14 +33,9 @@ install_requires =
     requests ~= 2.20
 
 [options.extras_require]
-all =
-    %(dandi)s
-    %(dandidav)s
 dandi =
     # Needed for timing `dandi ls` runs
     dandi
-dandidav =
-    dandidav @ git+https://github.com/dandi/dandi-webdav
 
 [options.packages.find]
 where = src

--- a/code/setup.cfg
+++ b/code/setup.cfg
@@ -32,6 +32,10 @@ install_requires =
     pyyaml
     requests ~= 2.20
 
+[options.extras_require]
+dandidav =
+    dandidav @ git+https://github.com/dandi/dandi-webdav
+
 [options.packages.find]
 where = src
 

--- a/code/src/healthstatus/__main__.py
+++ b/code/src/healthstatus/__main__.py
@@ -21,6 +21,7 @@ E = TypeVar("E", bound="Enum")
 
 
 class EnumSet(click.ParamType, Generic[E]):
+    # The enum's values must be strs.
     name = "enumset"
 
     def __init__(self, klass: type[E]) -> None:
@@ -249,6 +250,15 @@ def test_files(testname: str, files: tuple[Path, ...], save_results: bool) -> No
     default=set(MountType),
     show_default="all",
 )
+@click.option(
+    "--update-dataset/--no-update-dataset",
+    help=(
+        "Whether to pull the latest changes to the Dandisets dataset repository"
+        " before fuse-mounting"
+    ),
+    default=True,
+    show_default=True,
+)
 @click.argument(
     "assets",
     nargs=-1,
@@ -260,11 +270,13 @@ def time_mounts(
     dataset_path: Path | None,
     mount_point: Path,
     mounts: set[MountType],
+    update_dataset: bool,
 ) -> None:
     for mounter in iter_mounters(
         types=mounts,
         dataset_path=dataset_path,
         mount_path=mount_point,
+        update_dataset=update_dataset,
     ):
         log.info("Testing with mount type: %s", mounter.name)
         with mounter.mount():

--- a/code/src/healthstatus/__main__.py
+++ b/code/src/healthstatus/__main__.py
@@ -302,7 +302,7 @@ def time_mounts(
     update_dataset: bool,
 ) -> None:
     """Run timed tests on Dandiset assets using various mounting technologies"""
-    for t in TESTS:
+    for t in TIMED_TESTS:
         t.prepare()
     results = []
     for mounter in iter_mounters(

--- a/code/src/healthstatus/__main__.py
+++ b/code/src/healthstatus/__main__.py
@@ -272,6 +272,8 @@ def time_mounts(
     mounts: set[MountType],
     update_dataset: bool,
 ) -> None:
+    installer = MatNWBInstaller(MATNWB_INSTALL_DIR)
+    installer.install(update=True)
     for mounter in iter_mounters(
         types=mounts,
         dataset_path=dataset_path,

--- a/code/src/healthstatus/__main__.py
+++ b/code/src/healthstatus/__main__.py
@@ -66,7 +66,7 @@ def main() -> None:
 @click.option(
     "-d",
     "--dataset-path",
-    type=click.Path(file_okay=False, exists=True, path_type=Path),
+    type=click.Path(file_okay=False, path_type=Path),
     help="Directory containing a clone of dandi/dandisets",
     required=True,
 )
@@ -261,7 +261,7 @@ def test_files(testname: str, files: tuple[Path, ...], save_results: bool) -> No
 @click.option(
     "-d",
     "--dataset-path",
-    type=click.Path(file_okay=False, exists=True, path_type=Path),
+    type=click.Path(file_okay=False, path_type=Path),
     help=(
         "Directory containing a clone of dandi/dandisets.  Required when using"
         " the fusefs mount."

--- a/code/src/healthstatus/__main__.py
+++ b/code/src/healthstatus/__main__.py
@@ -64,7 +64,7 @@ def check(
     installer = MatNWBInstaller(MATNWB_INSTALL_DIR)
     installer.install(update=True)
     hs = HealthStatus(
-        backup_root=anyio.Path(str(mount_point)),
+        backup_root=mount_point,
         reports_root=Path.cwd(),
         dandisets=dandisets,
         dandiset_jobs=dandiset_jobs,
@@ -156,11 +156,9 @@ def report() -> None:
 @click.argument(
     "files",
     nargs=-1,
-    type=click.Path(exists=True, dir_okay=False, path_type=anyio.Path),
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
 )
-def test_files(
-    testname: str, files: tuple[anyio.Path, ...], save_results: bool
-) -> None:
+def test_files(testname: str, files: tuple[Path, ...], save_results: bool) -> None:
     versions = get_package_versions()
     installer = MatNWBInstaller(MATNWB_INSTALL_DIR)
     if "matnwb" in testname.lower():
@@ -177,7 +175,7 @@ def test_files(
                 dandiset, asset_paths = dandiset_cache[path]
             except KeyError:
                 dandiset = Dandiset(
-                    path=anyio.Path(path), reports_root=Path.cwd(), versions=versions
+                    path=path, reports_root=Path.cwd(), versions=versions
                 )
                 asset_paths = anyio.run(dandiset.get_asset_paths)
                 dandiset_cache[path] = (dandiset, asset_paths)
@@ -234,9 +232,7 @@ def time_mounts(
                     "Testing Dandiset %s, asset %s ...", a.dandiset_id, a.asset_path
                 )
                 fpath = mounter.resolve(a)
-                asset_obj = Asset(
-                    filepath=anyio.Path(str(fpath)), asset_path=a.asset_path
-                )
+                asset_obj = Asset(filepath=fpath, asset_path=a.asset_path)
                 for tname, tfunc in TIMED_TESTS.items():
                     log.info("Running test %r", tname)
                     r = anyio.run(tfunc, asset_obj)

--- a/code/src/healthstatus/__main__.py
+++ b/code/src/healthstatus/__main__.py
@@ -311,7 +311,7 @@ def time_mounts(
         mount_path=mount_point,
         update_dataset=update_dataset,
     ):
-        log.info("Testing with mount type: %s", mounter.name)
+        log.info("Testing with mount type: %s", mounter.type.value)
         with mounter.mount():
             for a in assets:
                 log.info(
@@ -326,7 +326,7 @@ def time_mounts(
                         log.info("Test passed in %f seconds", r.elapsed)
                         results.append(
                             MountBenchmark(
-                                mount_name=mounter.name,
+                                mount_type=mounter.type,
                                 asset=a,
                                 testname=tfunc.NAME,
                                 elapsed=r.elapsed,
@@ -343,12 +343,14 @@ def time_mounts(
                         assert r.outcome is Outcome.TIMEOUT
                         log.error("Test timed out")
                         sys.exit(1)
-    csvout = DictWriter(sys.stdout, ["mount", "dandiset", "asset", "test", "time_sec"])
+    csvout = DictWriter(
+        sys.stdout, ["mount_type", "dandiset", "asset", "test", "time_sec"]
+    )
     csvout.writeheader()
     for res in results:
         csvout.writerow(
             {
-                "mount": res.mount_name,
+                "mount_type": res.mount_type.value,
                 "dandiset": res.asset.dandiset_id,
                 "asset": res.asset.asset_path,
                 "test": res.testname,

--- a/code/src/healthstatus/checker.py
+++ b/code/src/healthstatus/checker.py
@@ -24,7 +24,6 @@ from .core import (
     log,
 )
 from .tests import TESTS, Test
-from .util import get_package_versions
 
 
 @dataclass
@@ -83,7 +82,7 @@ class HealthStatus:
     reports_root: Path
     dandisets: tuple[str, ...]
     dandiset_jobs: int
-    versions: dict[str, str] = field(default_factory=get_package_versions)
+    versions: dict[str, str]
 
     async def run_all(self) -> None:
         async def dowork(dandiset: Dandiset) -> None:

--- a/code/src/healthstatus/config.py
+++ b/code/src/healthstatus/config.py
@@ -1,11 +1,10 @@
 from pathlib import Path
-import anyio
 
 MATNWB_INSTALL_DIR = Path("matnwb")  # in current working directory
 
 PACKAGES_TO_VERSION = ["pynwb", "hdmf"]
 
-PYNWB_OPEN_LOAD_NS_SCRIPT = anyio.Path(__file__).with_name("pynwb_open_load_ns.py")
+PYNWB_OPEN_LOAD_NS_SCRIPT = Path(__file__).with_name("pynwb_open_load_ns.py")
 
 TIMEOUT = 3600
 

--- a/code/src/healthstatus/core.py
+++ b/code/src/healthstatus/core.py
@@ -7,7 +7,6 @@ from enum import Enum
 import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Union
-import anyio
 from pydantic import BaseModel, Field, field_validator
 import yaml
 from .yamllineno import load_yaml_lineno
@@ -32,7 +31,7 @@ class TestResult:
 
 @dataclass
 class Asset:
-    filepath: anyio.Path
+    filepath: Path
     asset_path: str
 
     def is_nwb(self) -> bool:

--- a/code/src/healthstatus/core.py
+++ b/code/src/healthstatus/core.py
@@ -27,6 +27,7 @@ class TestResult:
     asset_path: str
     outcome: Outcome
     output: Optional[str] = None
+    elapsed: Optional[float] = None
 
 
 @dataclass

--- a/code/src/healthstatus/mounts.py
+++ b/code/src/healthstatus/mounts.py
@@ -37,7 +37,7 @@ class AssetInDandiset:
 
 class MountType(Enum):
     FUSEFS = "fusefs"
-    WEBDAVFS = "webdavfs"
+    # WEBDAVFS = "webdavfs"
     DAVFS2 = "davfs2"
 
 
@@ -119,6 +119,9 @@ class FuseMounter(Mounter):
         return self.mount_path / asset.dandiset_id / asset.asset_path
 
 
+# Currently disabled due to webdavfs not supporting redirects
+# <https://github.com/miquels/webdavfs/issues/30>
+"""
 @dataclass
 class WebDavFSMounter(Mounter):
     mount_path: Path
@@ -158,6 +161,7 @@ class WebDavFSMounter(Mounter):
             / "draft"
             / asset.asset_path
         )
+"""
 
 
 @dataclass
@@ -208,8 +212,8 @@ def iter_mounters(
             update=update_dataset,
             logdir=logdir,
         )
-    if MountType.WEBDAVFS in types:
-        yield WebDavFSMounter(mount_path=mount_path)
+    # if MountType.WEBDAVFS in types:
+    #     yield WebDavFSMounter(mount_path=mount_path)
     if MountType.DAVFS2 in types:
         yield DavFS2Mounter(mount_path=mount_path)
 

--- a/code/src/healthstatus/mounts.py
+++ b/code/src/healthstatus/mounts.py
@@ -166,7 +166,16 @@ class WebDavFSMounter(DandiDavMounter):
     def mount_webdav(self, url: str) -> Iterator[None]:
         log.debug("Mounting webdavfs mount ...")
         subprocess.run(
-            ["sudo", "mount", "-t", "webdavfs", url, os.fspath(self.mount_path)],
+            [
+                "sudo",
+                "mount",
+                "-t",
+                "webdavfs",
+                "-o",
+                "allow_other",
+                url,
+                os.fspath(self.mount_path),
+            ],
             check=True,
         )
         try:

--- a/code/src/healthstatus/mounts.py
+++ b/code/src/healthstatus/mounts.py
@@ -79,6 +79,7 @@ class FuseMounter(Mounter):
     def mount(self) -> Iterator[None]:
         if not self.dataset_path.exists():
             log.info("Cloning dandi/dandisets to %s ...", self.dataset_path)
+            self.dataset_path.mkdir(parents=True, exist_ok=True)
             subprocess.run(
                 [
                     "datalad",
@@ -91,6 +92,7 @@ class FuseMounter(Mounter):
             get_dandisets(Dataset(self.dataset_path))
         elif self.update:
             update_dandisets(self.dataset_path)
+        self.mount_path.mkdir(parents=True, exist_ok=True)
         with (self.logdir / "fuse.log").open("wb") as fp:
             log.debug("Starting `datalad fusefs` process ...")
             with subprocess.Popen(
@@ -128,6 +130,7 @@ class WebDavFSMounter(Mounter):
     @contextmanager
     def mount(self) -> Iterator[None]:
         log.debug("Mounting webdavfs mount ...")
+        self.mount_path.mkdir(parents=True, exist_ok=True)
         subprocess.run(
             [
                 "sudo",
@@ -162,6 +165,7 @@ class DavFS2Mounter(Mounter):
     @contextmanager
     def mount(self) -> Iterator[None]:
         log.debug("Mounting davfs2 mount ...")
+        self.mount_path.mkdir(parents=True, exist_ok=True)
         subprocess.run(
             ["sudo", "mount", "-t", "davfs", DANDIDAV_URL, os.fspath(self.mount_path)],
             check=True,

--- a/code/src/healthstatus/mounts.py
+++ b/code/src/healthstatus/mounts.py
@@ -60,7 +60,18 @@ class FuseMounter(Mounter):
 
     @contextmanager
     def mount(self) -> Iterator[None]:
-        if self.update:
+        if not self.dataset_path.exists():
+            log.info("Cloning dandi/dandisets to %s ...", self.dataset_path)
+            subprocess.run(
+                [
+                    "datalad",
+                    "clone",
+                    "git@github.com:dandi/dandisets.git",
+                    os.fspath(self.dataset_path),
+                ],
+                check=True,
+            )
+        elif self.update:
             update_dandisets(self.dataset_path)
         with (self.logdir / "fuse.log").open("wb") as fp:
             log.debug("Starting `datalad fusefs` process ...")

--- a/code/src/healthstatus/mounts.py
+++ b/code/src/healthstatus/mounts.py
@@ -179,7 +179,16 @@ class DavFS2Mounter(DandiDavMounter):
 
     @contextmanager
     def mount_webdav(self, url: str) -> Iterator[None]:
-        raise NotImplementedError
+        log.debug("Mounting davfs2 mount ...")
+        subprocess.run(
+            ["sudo", "mount", "-t", "davfs", url, os.fspath(self.mount_path)],
+            check=True,
+        )
+        try:
+            yield
+        finally:
+            log.debug("Unmounting davfs2 mount ...")
+            subprocess.run(["sudo", "umount", os.fspath(self.mount_path)], check=True)
 
 
 def iter_mounters(

--- a/code/src/healthstatus/mounts.py
+++ b/code/src/healthstatus/mounts.py
@@ -13,13 +13,13 @@ from time import sleep
 import click
 from ghreq import Client
 import requests
-from .core import log
+from .core import AssetPath, log
 
 
 @dataclass
 class AssetInDandiset:
     dandiset_id: str
-    asset_path: str
+    asset_path: AssetPath
 
     @classmethod
     def parse(cls, s: str) -> AssetInDandiset:
@@ -29,7 +29,7 @@ class AssetInDandiset:
                 f"invalid asset-in-dandiset: {s!r}: must be in form"
                 " <dandiset-id>/<asset-path>"
             )
-        return AssetInDandiset(dandiset_id, asset_path)
+        return AssetInDandiset(dandiset_id, AssetPath(asset_path))
 
 
 @dataclass

--- a/code/src/healthstatus/mounts.py
+++ b/code/src/healthstatus/mounts.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+from abc import ABC, abstractmethod
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, contextmanager
+from dataclasses import dataclass, field
 import os
 from pathlib import Path
 import re
@@ -12,38 +14,162 @@ import requests
 from .core import log
 
 
-@contextmanager
-def fused(
-    dataset_path: str | os.PathLike[str],
-    mount_path: str | os.PathLike[str],
-    update: bool = False,
-    logdir: Path | None = None,
-) -> Iterator[None]:
-    if update:
-        update_dandisets(Path(dataset_path))
-    if logdir is None:
-        logdir = Path()
-    with (logdir / "fuse.log").open("wb") as fp:
-        log.debug("Starting `datalad fusefs` process ...")
-        with subprocess.Popen(
-            [
-                "datalad",
-                "fusefs",
-                "-d",
-                os.fspath(dataset_path),
-                "--foreground",
-                "--mode-transparent",
-                os.fspath(mount_path),
-            ],
-            stdout=fp,
-            stderr=fp,
-        ) as p:
-            sleep(3)
-            try:
+@dataclass
+class AssetInDandiset:
+    dandiset_id: str
+    asset_path: str
+
+    @classmethod
+    def parse(cls, s: str) -> AssetInDandiset:
+        (dandiset_id, _, asset_path) = s.partition("/")
+        if not asset_path or not re.fullmatch(r"[0-9]{6}", dandiset_id):
+            raise ValueError(
+                f"invalid asset-in-dandiset: {s!r}: must be in form"
+                " <dandiset-id>/<asset-path>"
+            )
+        return AssetInDandiset(dandiset_id, asset_path)
+
+
+class Mounter(ABC):
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        ...
+
+    @abstractmethod
+    def mount(self) -> AbstractContextManager[None]:
+        ...
+
+    @abstractmethod
+    def resolve(self, asset: AssetInDandiset) -> Path:
+        ...
+
+
+@dataclass
+class FuseMounter(Mounter):
+    dataset_path: Path
+    mount_path: Path
+    update: bool = True
+    logdir: Path = field(default_factory=Path)
+
+    @property
+    def name(self) -> str:
+        return "fusefs"
+
+    @contextmanager
+    def mount(self) -> Iterator[None]:
+        if self.update:
+            update_dandisets(self.dataset_path)
+        with (self.logdir / "fuse.log").open("wb") as fp:
+            log.debug("Starting `datalad fusefs` process ...")
+            with subprocess.Popen(
+                [
+                    "datalad",
+                    "fusefs",
+                    "-d",
+                    os.fspath(self.dataset_path),
+                    "--foreground",
+                    "--mode-transparent",
+                    os.fspath(self.mount_path),
+                ],
+                stdout=fp,
+                stderr=fp,
+            ) as p:
+                sleep(3)
+                try:
+                    yield
+                finally:
+                    log.debug("Terminating `datalad fusefs` process ...")
+                    p.send_signal(SIGINT)
+
+    def resolve(self, asset: AssetInDandiset) -> Path:
+        return self.mount_path / asset.dandiset_id / asset.asset_path
+
+
+@dataclass
+class DandiDavMounter(Mounter):
+    mount_path: Path
+    logdir: Path = field(default_factory=Path)
+
+    @contextmanager
+    def dandidav(self) -> Iterator[str]:
+        with (self.logdir / "dandidav.log").open("wb") as fp:
+            log.debug("Starting `dandidav` process ...")
+            with subprocess.Popen(["dandidav"], stdout=fp, stderr=fp) as p:
+                try:
+                    url = "http://127.0.0.1:8080"
+                    for _ in range(10):
+                        try:
+                            requests.get(url, timeout=1)
+                        except requests.RequestException:
+                            sleep(1)
+                        else:
+                            break
+                    else:
+                        raise RuntimeError("WebDAV server did not start up time")
+                    yield url
+                finally:
+                    log.debug("Terminating `dandidav` process ...")
+                    p.send_signal(SIGINT)
+
+    @abstractmethod
+    def mount_webdav(self, url: str) -> AbstractContextManager[None]:
+        ...
+
+    @contextmanager
+    def mount(self) -> Iterator[None]:
+        with self.dandidav() as url:
+            with self.mount_webdav(url):
                 yield
-            finally:
-                log.debug("Terminating `datalad fusefs` process ...")
-                p.send_signal(SIGINT)
+
+    def resolve(self, asset: AssetInDandiset) -> Path:
+        return self.mount_path / asset.dandiset_id / "draft" / asset.asset_path
+
+
+class WebDavFSMounter(DandiDavMounter):
+    @property
+    def name(self) -> str:
+        return "webdavfs"
+
+    @contextmanager
+    def mount_webdav(self, url: str) -> Iterator[None]:
+        log.debug("Mounting webdavfs mount ...")
+        subprocess.run(
+            ["sudo", "mount", "-t", "webdavfs", url, os.fspath(self.mount_path)],
+            check=True,
+        )
+        try:
+            yield
+        finally:
+            log.debug("Unmounting webdavfs mount ...")
+            subprocess.run(["sudo", "umount", os.fspath(self.mount_path)], check=True)
+
+
+class DavFS2Mounter(DandiDavMounter):
+    @property
+    def name(self) -> str:
+        return "davfs2"
+
+    @contextmanager
+    def mount_webdav(self, url: str) -> Iterator[None]:
+        raise NotImplementedError
+
+
+@dataclass
+class MounterFactory:
+    dataset_path: Path
+    mount_path: Path
+    logdir: Path = field(default_factory=Path)
+
+    def iter_mounters(self) -> Iterator[Mounter]:
+        yield FuseMounter(
+            dataset_path=self.dataset_path,
+            mount_path=self.mount_path,
+            update=True,
+            logdir=self.logdir,
+        )
+        yield WebDavFSMounter(mount_path=self.mount_path, logdir=self.logdir)
+        yield DavFS2Mounter(mount_path=self.mount_path, logdir=self.logdir)
 
 
 def update_dandisets(dataset_path: Path) -> None:
@@ -68,46 +194,3 @@ def update_dandisets(dataset_path: Path) -> None:
         datasets.discard(name)
     if datasets:
         ds.get(path=list(datasets), jobs=5, get_data=False)
-
-
-@contextmanager
-def dandidav(logdir: Path | None = None) -> Iterator[str]:
-    if logdir is None:
-        logdir = Path()
-    with (logdir / "dandidav.log").open("wb") as fp:
-        log.debug("Starting `dandidav` process ...")
-        with subprocess.Popen(["dandidav"], stdout=fp, stderr=fp) as p:
-            try:
-                url = "http://127.0.0.1:8080"
-                for _ in range(10):
-                    try:
-                        requests.get(url, timeout=1)
-                    except requests.RequestException:
-                        sleep(1)
-                    else:
-                        break
-                else:
-                    raise RuntimeError("WebDAV server did not start up time")
-                yield url
-            finally:
-                log.debug("Terminating `dandidav` process ...")
-                p.send_signal(SIGINT)
-
-
-@contextmanager
-def webdavfs(url: str, mount_path: str | os.PathLike[str]) -> Iterator[None]:
-    log.debug("Mounting webdavfs mount ...")
-    subprocess.run(
-        ["sudo", "mount", "-t", "webdavfs", url, os.fspath(mount_path)],
-        check=True,
-    )
-    try:
-        yield
-    finally:
-        log.debug("Unmounting webdavfs mount ...")
-        subprocess.run(["sudo", "umount", os.fspath(mount_path)], check=True)
-
-
-@contextmanager
-def davfs2(url: str, mount_path: str | os.PathLike[str]) -> Iterator[None]:
-    raise NotImplementedError

--- a/code/src/healthstatus/mounts.py
+++ b/code/src/healthstatus/mounts.py
@@ -24,6 +24,7 @@ def fused(
     if logdir is None:
         logdir = Path()
     with (logdir / "fuse.log").open("wb") as fp:
+        log.debug("Starting `datalad fusefs` process ...")
         with subprocess.Popen(
             [
                 "datalad",
@@ -41,6 +42,7 @@ def fused(
             try:
                 yield
             finally:
+                log.debug("Terminating `datalad fusefs` process ...")
                 p.send_signal(SIGINT)
 
 
@@ -73,6 +75,7 @@ def dandidav(logdir: Path | None = None) -> Iterator[str]:
     if logdir is None:
         logdir = Path()
     with (logdir / "dandidav.log").open("wb") as fp:
+        log.debug("Starting `dandidav` process ...")
         with subprocess.Popen(["dandidav"], stdout=fp, stderr=fp) as p:
             try:
                 url = "http://127.0.0.1:8080"
@@ -87,11 +90,13 @@ def dandidav(logdir: Path | None = None) -> Iterator[str]:
                     raise RuntimeError("WebDAV server did not start up time")
                 yield url
             finally:
+                log.debug("Terminating `dandidav` process ...")
                 p.send_signal(SIGINT)
 
 
 @contextmanager
 def webdavfs(url: str, mount_path: str | os.PathLike[str]) -> Iterator[None]:
+    log.debug("Mounting webdavfs mount ...")
     subprocess.run(
         ["sudo", "mount", "-t", "webdavfs", url, os.fspath(mount_path)],
         check=True,
@@ -99,6 +104,7 @@ def webdavfs(url: str, mount_path: str | os.PathLike[str]) -> Iterator[None]:
     try:
         yield
     finally:
+        log.debug("Unmounting webdavfs mount ...")
         subprocess.run(["sudo", "umount", os.fspath(mount_path)], check=True)
 
 

--- a/code/src/healthstatus/mounts.py
+++ b/code/src/healthstatus/mounts.py
@@ -151,7 +151,13 @@ class WebDavFSMounter(Mounter):
             subprocess.run(["sudo", "umount", os.fspath(self.mount_path)], check=True)
 
     def resolve(self, asset: AssetInDandiset) -> Path:
-        return self.mount_path / asset.dandiset_id / "draft" / asset.asset_path
+        return (
+            self.mount_path
+            / "dandisets"
+            / asset.dandiset_id
+            / "draft"
+            / asset.asset_path
+        )
 
 
 @dataclass
@@ -177,7 +183,13 @@ class DavFS2Mounter(Mounter):
             subprocess.run(["sudo", "umount", os.fspath(self.mount_path)], check=True)
 
     def resolve(self, asset: AssetInDandiset) -> Path:
-        return self.mount_path / asset.dandiset_id / "draft" / asset.asset_path
+        return (
+            self.mount_path
+            / "dandisets"
+            / asset.dandiset_id
+            / "draft"
+            / asset.asset_path
+        )
 
 
 def iter_mounters(

--- a/code/src/healthstatus/mounts.py
+++ b/code/src/healthstatus/mounts.py
@@ -32,6 +32,14 @@ class AssetInDandiset:
         return AssetInDandiset(dandiset_id, asset_path)
 
 
+@dataclass
+class MountBenchmark:
+    mount_name: str
+    asset: AssetInDandiset
+    testname: str
+    elapsed: float
+
+
 class Mounter(ABC):
     @property
     @abstractmethod

--- a/code/src/healthstatus/mounts.py
+++ b/code/src/healthstatus/mounts.py
@@ -12,6 +12,7 @@ import subprocess
 from time import sleep
 from typing import Any
 import click
+from datalad.api import Dataset
 from ghreq import Client
 from .core import AssetPath, log
 
@@ -76,8 +77,6 @@ class FuseMounter(Mounter):
 
     @contextmanager
     def mount(self) -> Iterator[None]:
-        from datalad.api import Dataset
-
         if not self.dataset_path.exists():
             log.info("Cloning dandi/dandisets to %s ...", self.dataset_path)
             subprocess.run(
@@ -200,12 +199,7 @@ def iter_mounters(
 
 
 def update_dandisets(dataset_path: Path) -> None:
-    # Importing this at the top of the file leads to some weird import error
-    # when running tests:
-    from datalad.api import Dataset
-
     log.info("Updating Dandisets dataset ...")
-
     ds = Dataset(dataset_path)
     ds.update(follow="parentds", how="ff-only", recursive=True, recursion_limit=1)
     get_dandisets(ds)

--- a/code/src/healthstatus/mounts.py
+++ b/code/src/healthstatus/mounts.py
@@ -167,6 +167,7 @@ def iter_mounters(
     types: set[MountType],
     dataset_path: Path | None,
     mount_path: Path,
+    update_dataset: bool = True,
 ) -> Iterator[Mounter]:
     logdir = Path()
     if MountType.FUSEFS in types:
@@ -175,7 +176,7 @@ def iter_mounters(
         yield FuseMounter(
             dataset_path=dataset_path,
             mount_path=mount_path,
-            update=True,
+            update=update_dataset,
             logdir=logdir,
         )
     if MountType.WEBDAVFS in types:

--- a/code/src/healthstatus/mounts.py
+++ b/code/src/healthstatus/mounts.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+from collections.abc import Iterator
+from contextlib import contextmanager
+import os
+from pathlib import Path
+import re
+from signal import SIGINT
+import subprocess
+from time import sleep
+from ghreq import Client
+from .core import log
+
+
+@contextmanager
+def fused(
+    dataset_path: str | os.PathLike[str],
+    mount_path: str | os.PathLike[str],
+    update: bool = False,
+    logdir: Path | None = None,
+) -> Iterator[None]:
+    if update:
+        update_dandisets(Path(dataset_path))
+    if logdir is None:
+        logdir = Path()
+    with (logdir / "fuse.log").open("wb") as fp:
+        with subprocess.Popen(
+            [
+                "datalad",
+                "fusefs",
+                "-d",
+                os.fspath(dataset_path),
+                "--foreground",
+                "--mode-transparent",
+                os.fspath(mount_path),
+            ],
+            stdout=fp,
+            stderr=fp,
+        ) as p:
+            sleep(3)
+            try:
+                yield
+            finally:
+                p.send_signal(SIGINT)
+
+
+def update_dandisets(dataset_path: Path) -> None:
+    # Importing this at the top of the file leads to some weird import error
+    # when running tests:
+    from datalad.api import Dataset
+
+    log.info("Updating Dandisets dataset ...")
+    # Fetch just the public repositories from the dandisets org, and then get
+    # or update just those subdatasets rather than trying to get all
+    # subdatasets and failing on private/embargoed ones
+    datasets = set()
+    with Client() as client:
+        for repo in client.paginate("/users/dandisets/repos"):
+            name = repo["name"]
+            if re.fullmatch("[0-9]{6}", name):
+                datasets.add(name)
+    ds = Dataset(dataset_path)
+    ds.update(follow="parentds", how="ff-only", recursive=True, recursion_limit=1)
+    for sub in ds.subdatasets(state="present"):
+        name = Path(sub["path"]).relative_to(dataset_path).as_posix()
+        datasets.discard(name)
+    if datasets:
+        ds.get(path=list(datasets), jobs=5, get_data=False)

--- a/code/src/healthstatus/mounts.py
+++ b/code/src/healthstatus/mounts.py
@@ -32,9 +32,15 @@ class AssetInDandiset:
         return AssetInDandiset(dandiset_id, AssetPath(asset_path))
 
 
+class MountType(Enum):
+    FUSEFS = "fusefs"
+    WEBDAVFS = "webdavfs"
+    DAVFS2 = "davfs2"
+
+
 @dataclass
 class MountBenchmark:
-    mount_name: str
+    mount_type: MountType
     asset: AssetInDandiset
     testname: str
     elapsed: float
@@ -43,7 +49,7 @@ class MountBenchmark:
 class Mounter(ABC):
     @property
     @abstractmethod
-    def name(self) -> str:
+    def type(self) -> MountType:
         ...
 
     @abstractmethod
@@ -63,8 +69,8 @@ class FuseMounter(Mounter):
     logdir: Path = field(default_factory=Path)
 
     @property
-    def name(self) -> str:
-        return "fusefs"
+    def type(self) -> MountType:
+        return MountType.FUSEFS
 
     @contextmanager
     def mount(self) -> Iterator[None]:
@@ -149,8 +155,8 @@ class DandiDavMounter(Mounter):
 
 class WebDavFSMounter(DandiDavMounter):
     @property
-    def name(self) -> str:
-        return "webdavfs"
+    def type(self) -> MountType:
+        return MountType.WEBDAVFS
 
     @contextmanager
     def mount_webdav(self, url: str) -> Iterator[None]:
@@ -168,18 +174,12 @@ class WebDavFSMounter(DandiDavMounter):
 
 class DavFS2Mounter(DandiDavMounter):
     @property
-    def name(self) -> str:
-        return "davfs2"
+    def type(self) -> MountType:
+        return MountType.DAVFS2
 
     @contextmanager
     def mount_webdav(self, url: str) -> Iterator[None]:
         raise NotImplementedError
-
-
-class MountType(Enum):
-    FUSEFS = "fusefs"
-    WEBDAVFS = "webdavfs"
-    DAVFS2 = "davfs2"
 
 
 def iter_mounters(

--- a/code/src/healthstatus/mounts.py
+++ b/code/src/healthstatus/mounts.py
@@ -88,3 +88,20 @@ def dandidav(logdir: Path | None = None) -> Iterator[str]:
                 yield url
             finally:
                 p.send_signal(SIGINT)
+
+
+@contextmanager
+def webdavfs(url: str, mount_path: str | os.PathLike[str]) -> Iterator[None]:
+    subprocess.run(
+        ["sudo", "mount", "-t", "webdavfs", url, os.fspath(mount_path)],
+        check=True,
+    )
+    try:
+        yield
+    finally:
+        subprocess.run(["sudo", "umount", os.fspath(mount_path)], check=True)
+
+
+@contextmanager
+def davfs2(url: str, mount_path: str | os.PathLike[str]) -> Iterator[None]:
+    raise NotImplementedError

--- a/code/src/healthstatus/util.py
+++ b/code/src/healthstatus/util.py
@@ -1,15 +1,9 @@
 from __future__ import annotations
 from dataclasses import dataclass
-from importlib.metadata import version
 from pathlib import Path
 import subprocess
 import requests
-from .config import PACKAGES_TO_VERSION
 from .core import log
-
-
-def get_package_versions() -> dict[str, str]:
-    return {pkg: version(pkg) for pkg in PACKAGES_TO_VERSION}
 
 
 @dataclass
@@ -64,7 +58,7 @@ class MatNWBInstaller:
 
     def install(self, update: bool = True) -> None:
         if self.download(update):
-            log.info("Installing NeurodataWithoutBorders/matnwb")
+            log.info("Cleaning NeurodataWithoutBorders/matnwb")
             subprocess.run(
                 ["git", "clean", "-dxf"], cwd=str(self.install_dir), check=True
             )

--- a/tools/bench.sh
+++ b/tools/bench.sh
@@ -22,4 +22,4 @@ dandisets-healthstatus time-mounts \
     -m "$MOUNT_PATH" \
     --no-update-dataset \
     --mounts fusefs,davfs2 \
-    000016/sub-mouse1-fni16/sub-mouse1-fni16_ses-161228151100.nwb
+    000005/sub-anm236462/sub-anm236462_ses-20140210_behavior+icephys.nwb

--- a/tools/bench.sh
+++ b/tools/bench.sh
@@ -3,7 +3,7 @@ set -ex
 
 PYTHON="$HOME"/miniconda3/bin/python
 DANDISETS_PATH="$HOME"/healthstatus-dandisets
-MOUNT_PATH=/tmp/dandisets-fuse
+MOUNT_PATH=/mnt/backup/dandi/dandisets-healthstatus/dandisets-fuse
 
 cd "$(dirname "$0")"/..
 

--- a/tools/bench.sh
+++ b/tools/bench.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -ex
+
+PYTHON="$HOME"/miniconda3/bin/python
+DANDISETS_PATH=/mnt/backup/dandi/dandisets-healthstatus/dandisets
+MOUNT_PATH=/tmp/dandisets-fuse
+
+cd "$(dirname "$0")"/..
+
+"$PYTHON" -m virtualenv --clear venv
+. venv/bin/activate
+pip install './code[dandi]'
+pip install 'git+https://github.com/jwodder/filesystem_spec@rlock-cache'
+
+dandisets-healthstatus time-mounts \
+    -d "$DANDISETS_PATH" \
+    -m "$MOUNT_PATH" \
+    --no-update-dataset \
+    --mounts fusefs,davfs2 \
+    000016/sub-mouse1-fni16/sub-mouse1-fni16_ses-161228151100.nwb

--- a/tools/bench.sh
+++ b/tools/bench.sh
@@ -2,15 +2,20 @@
 set -ex
 
 PYTHON="$HOME"/miniconda3/bin/python
-DANDISETS_PATH=/mnt/backup/dandi/dandisets-healthstatus/dandisets
+DANDISETS_PATH="$HOME"/healthstatus-dandisets
 MOUNT_PATH=/tmp/dandisets-fuse
 
 cd "$(dirname "$0")"/..
 
-"$PYTHON" -m virtualenv --clear venv
-. venv/bin/activate
-pip install './code[dandi]'
-pip install 'git+https://github.com/jwodder/filesystem_spec@rlock-cache'
+if [ ! -e venv ]
+then
+    "$PYTHON" -m virtualenv venv
+    . venv/bin/activate
+    pip install -e './code[dandi]'
+    pip install 'git+https://github.com/jwodder/filesystem_spec@rlock-cache'
+else
+    . venv/bin/activate
+fi
 
 dandisets-healthstatus time-mounts \
     -d "$DANDISETS_PATH" \

--- a/tools/run.sh
+++ b/tools/run.sh
@@ -3,7 +3,7 @@ set -ex
 
 PYTHON="$HOME"/miniconda3/bin/python
 DANDISETS_PATH=/mnt/backup/dandi/dandisets-healthstatus/dandisets
-MOUNT_PATH=/mnt/backup/dandi/dandisets-healthstatus/dandisets-fuse
+MOUNT_PATH=/tmp/dandisets-fuse
 
 cd "$(dirname "$0")"/..
 #git reset --hard HEAD

--- a/tools/run.sh
+++ b/tools/run.sh
@@ -3,7 +3,7 @@ set -ex
 
 PYTHON="$HOME"/miniconda3/bin/python
 DANDISETS_PATH=/mnt/backup/dandi/dandisets-healthstatus/dandisets
-MOUNT_PATH=/tmp/dandisets-fuse
+MOUNT_PATH=/mnt/backup/dandi/dandisets-healthstatus/dandisets-fuse
 
 cd "$(dirname "$0")"/..
 #git reset --hard HEAD


### PR DESCRIPTION
Closes #66.

To do:

- [x] Implement mounting & unmounting with webdavfs
- [x] Implement mounting & unmounting with davfs2
- [x] Implement timing of the following tests:
    - [x] `pynwb_open_load_ns`
    - [x] `matnwb_nwbRead`
    - [x] `DANDI_CACHE=ignore dandi ls` (to load metadata) on a single local asset
- [x] Add a subcommand for doing all the benchmarking at once (mounting each mount and running & timing of tests)
    - [x] Emit a summary of timing results
    - [x] Add an option for only using specified mount types
    - [x] Add an option for whether to update the local clone of the dandisets repo for fusefs
- [x] Add a subcommand that just runs & times the tests against a path given on the command line
- [x] When mounting with fusefs, clone the dandisets repository first if it isn't present at the dataset path.
- PROBLEM: webdavfs doesn't support redirects: https://github.com/miquels/webdavfs/issues/30
    - [x] Comment out the webdavfs support for now
- [x] Document how to set up davfs2 for use by dandisets-healthstatus
- [x] Actually run benchmarks
    - Run on smaug
    - The assets to test should be one (or more?) sample assets of some "typical" size (a few GBs).  `sub-mouse1-fni16/sub-mouse1-fni16_ses-161228151100.nwb` in 000016 is suggested as a possible candidate.