### PR TITLE
`random-outdated-asset-first` mode: Consider new assets and only consider NWBs

### DIFF
--- a/code/setup.cfg
+++ b/code/setup.cfg
@@ -23,6 +23,7 @@ install_requires =
     async_generator ~= 1.10; python_version < '3.10'
     click >= 8.0
     ghreq ~= 0.1
+    httpx ~= 0.22
     hdmf
     packaging
     pydantic ~= 2.0

--- a/code/src/healthstatus/__main__.py
+++ b/code/src/healthstatus/__main__.py
@@ -219,6 +219,7 @@ def test_files(testname: str, files: tuple[Path, ...], save_results: bool) -> No
             except KeyError:
                 reporter = DandisetReporter(
                     identifier=path.name,
+                    draft_modified=None,
                     reportdir=Path("results", path.name),
                     versions=pkg_versions,
                 )

--- a/code/src/healthstatus/__main__.py
+++ b/code/src/healthstatus/__main__.py
@@ -134,7 +134,7 @@ def report() -> None:
     assets_seen = 0
     for p in Path("results").iterdir():
         if re.fullmatch(r"\d{6,}", p.name) and p.is_dir():
-            status = DandisetStatus.from_file(p.name, p / "status.yaml")
+            status = DandisetStatus.from_file(p / "status.yaml")
             passed, failed, timedout = status.combined_counts()
             asset_qtys[Outcome.PASS] += passed
             asset_qtys[Outcome.FAIL] += failed

--- a/code/src/healthstatus/adandi.py
+++ b/code/src/healthstatus/adandi.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+from collections.abc import AsyncGenerator
+from dataclasses import InitVar, dataclass, field
+from datetime import datetime
+import platform
+import sys
+from typing import Any
+from anyio.abc import AsyncResource
+import httpx
+from pydantic import BaseModel
+from .aioutil import arequest
+
+if sys.version_info[:2] >= (3, 10):
+    from contextlib import aclosing
+else:
+    from async_generator import aclosing
+
+USER_AGENT = "dandisets-healthstatus ({}) httpx/{} {}/{}".format(
+    "https://github.com/dandi/dandisets-healthstatus",
+    httpx.__version__,
+    platform.python_implementation(),
+    platform.python_version(),
+)
+
+
+@dataclass
+class AsyncDandiClient(AsyncResource):
+    api_url: str
+    token: InitVar[str | None] = None
+    session: httpx.AsyncClient = field(init=False)
+
+    def __post_init__(self, token: str | None) -> None:
+        headers = {"User-Agent": USER_AGENT}
+        if token is not None:
+            headers["Authorization"] = f"token {token}"
+        self.session = httpx.AsyncClient(
+            base_url=self.api_url,
+            headers=headers,
+            follow_redirects=True,
+        )
+
+    async def aclose(self) -> None:
+        await self.session.aclose()
+
+    def get_url(self, path: str) -> str:
+        if path.lower().startswith(("http://", "https://")):
+            return path
+        else:
+            return self.api_url.rstrip("/") + "/" + path.lstrip("/")
+
+    async def get(self, path: str, **kwargs: Any) -> Any:
+        return (await arequest(self.session, "GET", path, **kwargs)).json()
+
+    async def paginate(
+        self,
+        path: str,
+        page_size: int | None = None,
+        params: dict | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator:
+        """
+        Paginate through the resources at the given path: GET the path, yield
+        the values in the ``"results"`` key, and repeat with the URL in the
+        ``"next"`` key until it is ``null``.
+        """
+        if page_size is not None:
+            if params is None:
+                params = {}
+            params["page_size"] = page_size
+        r = await self.get(path, params=params, **kwargs)
+        while True:
+            for item in r["results"]:
+                yield item
+            if r.get("next"):
+                r = await self.get(r["next"], **kwargs)
+            else:
+                break
+
+    async def get_dandiset(self, dandiset_id: str) -> DandisetInfo:
+        return DandisetInfo.from_raw_response(
+            await self.get(f"/dandisets/{dandiset_id}/")
+        )
+
+    async def get_dandisets(self) -> AsyncGenerator[DandisetInfo, None]:
+        async with aclosing(self.paginate("/dandisets/")) as ait:
+            async for data in ait:
+                yield DandisetInfo.from_raw_response(data)
+
+    async def get_asset_paths(self, dandiset_id: str) -> AsyncGenerator[str, None]:
+        async with aclosing(
+            self.paginate(
+                f"/dandisets/{dandiset_id}/versions/draft/assets/",
+                params={"order": "created", "page_size": "1000"},
+            )
+        ) as ait:
+            async for item in ait:
+                yield item["path"]
+
+
+@dataclass
+class DandisetInfo:
+    identifier: str
+    draft_modified: datetime
+
+    @classmethod
+    def from_raw_response(cls, data: dict[str, Any]) -> DandisetInfo:
+        resp = DandisetResponse.model_validate(data)
+        return cls(
+            identifier=resp.identifier, draft_modified=resp.draft_version.modified
+        )
+
+
+class VersionInfo(BaseModel):
+    modified: datetime
+
+
+class DandisetResponse(BaseModel):
+    identifier: str
+    draft_version: VersionInfo

--- a/code/src/healthstatus/aioutil.py
+++ b/code/src/healthstatus/aioutil.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
-from collections.abc import AsyncGenerator, Callable
+from collections.abc import AsyncGenerator, Callable, Container, Iterator
 import math
+import random
+import ssl
 import sys
-from typing import Awaitable, TypeVar
+from typing import Any, Awaitable, TypeVar
 import anyio
 from anyio.streams.memory import MemoryObjectReceiveStream
+import httpx
+from .core import log
 
 if sys.version_info[:2] >= (3, 10):
     from contextlib import aclosing
@@ -32,3 +36,66 @@ async def pool_tasks(
         async with sender, aclosing(inputs):
             async for item in inputs:
                 await sender.send(item)
+
+
+async def arequest(
+    client: httpx.AsyncClient,
+    method: str,
+    url: str,
+    retry_on: Container[int] = (),
+    **kwargs: Any,
+) -> httpx.Response:
+    waits = exp_wait(attempts=15, base=2)
+    kwargs.setdefault("timeout", 60)
+    while True:
+        try:
+            r = await client.request(method, url, follow_redirects=True, **kwargs)
+            r.raise_for_status()
+        except (httpx.HTTPError, ssl.SSLError) as e:
+            if isinstance(e, (httpx.RequestError, ssl.SSLError)) or (
+                isinstance(e, httpx.HTTPStatusError)
+                and (
+                    e.response.status_code >= 500 or e.response.status_code in retry_on
+                )
+            ):
+                try:
+                    delay = next(waits)
+                except StopIteration:
+                    raise e
+                log.warning(
+                    "Retrying %s request to %s in %f seconds as it raised %s: %s",
+                    method.upper(),
+                    url,
+                    delay,
+                    type(e).__name__,
+                    str(e),
+                )
+                await anyio.sleep(delay)
+                continue
+            else:
+                raise
+        return r
+
+
+def exp_wait(
+    base: float = 1.25,
+    multiplier: float = 1,
+    attempts: int | None = None,
+    jitter: float = 0.1,
+) -> Iterator[float]:
+    """
+    Returns a generator of values usable as `sleep()` times when retrying
+    something with exponential backoff.
+
+    :param float base:
+    :param float multiplier: value to multiply values by after exponentiation
+    :param Optional[int] attempts: how many values to yield; set to `None` to
+        yield forever
+    :param Optional[float] jitter: add +1 of that jitter ratio for the time
+        randomly so that wait track is unique.
+    :rtype: Iterator[float]
+    """
+    n = 0
+    while attempts is None or n < attempts:
+        yield (base**n * multiplier) * (1 + (random.random() - 0.5) * jitter)
+        n += 1

--- a/code/src/healthstatus/checker.py
+++ b/code/src/healthstatus/checker.py
@@ -243,7 +243,7 @@ class DandisetReporter:
 
     def __post_init__(self) -> None:
         try:
-            self.status = DandisetStatus.from_file(self.identifier, self.statusfile)
+            self.status = DandisetStatus.from_file(self.statusfile)
         except FileNotFoundError:
             self.status = DandisetStatus(
                 dandiset=self.identifier,

--- a/code/src/healthstatus/checker.py
+++ b/code/src/healthstatus/checker.py
@@ -234,7 +234,7 @@ class DandisetTester:
 @dataclass
 class DandisetReporter:
     identifier: str
-    draft_modified: datetime
+    draft_modified: datetime | None
     reportdir: Path
     versions: dict[str, str]
     status: DandisetStatus = field(init=False)

--- a/code/src/healthstatus/checker.py
+++ b/code/src/healthstatus/checker.py
@@ -251,6 +251,8 @@ class DandisetReporter:
                 tests=[TestStatus(name=testname) for testname in TESTS.keys()],
                 versions=self.versions,
             )
+        else:
+            self.status.draft_modified = self.draft_modified
 
     @property
     def statusfile(self) -> Path:

--- a/code/src/healthstatus/checker.py
+++ b/code/src/healthstatus/checker.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from random import choice
 import sys
 import textwrap
+from types import TracebackType
 from typing import Optional
 import anyio
 from .adandi import AsyncDandiClient, DandisetInfo
@@ -24,6 +25,7 @@ from .core import (
     log,
 )
 from .tests import TESTS, Test
+from .util import nowstamp
 
 if sys.version_info[:2] >= (3, 10):
     from contextlib import aclosing
@@ -94,124 +96,113 @@ class HealthStatus:
         self.client = AsyncDandiClient(api_url=DANDI_API_URL)
 
     async def run_all(self) -> None:
-        async def dowork(dandiset: Dandiset) -> None:
-            (await dandiset.test_all_assets()).dump()
+        async def dowork(dst: DandisetTester) -> None:
+            await dst.test_all_assets()
+            dst.reporter.dump()
 
         await pool_tasks(dowork, self.aiterdandisets(), self.dandiset_jobs)
 
     async def run_random_assets(self, mode: str) -> None:
         if mode == "random-asset":
-            tester = Dandiset.test_random_asset
+            tester = DandisetTester.test_random_asset
         elif mode == "random-outdated-asset-first":
-            tester = Dandiset.test_random_outdated_asset_first
+            tester = DandisetTester.test_random_outdated_asset_first
         else:
             raise ValueError(f"Invalid random asset mode: {mode!r}")
 
-        async def dowork(dandiset: Dandiset) -> None:
-            report = await tester(dandiset)
-            if report is not None:
-                report.dump()
+        async def dowork(dst: DandisetTester) -> None:
+            if await tester(dst):
+                dst.reporter.dump()
 
         await pool_tasks(dowork, self.aiterdandisets(), self.dandiset_jobs)
 
-    async def aiterdandisets(self) -> AsyncGenerator[Dandiset, None]:
-        if self.dandisets:
-            for did in self.dandisets:
-                yield self.make_dandiset(await self.client.get_dandiset(did))
-        else:
-            async with aclosing(self.client.get_dandisets()) as ait:
-                async for info in ait:
-                    log.info("Found Dandiset %s", info.identifier)
-                    yield self.make_dandiset(info)
+    async def aiterdandisets(self) -> AsyncGenerator[DandisetTester, None]:
+        async def inner() -> AsyncGenerator[DandisetInfo, None]:
+            if self.dandisets:
+                for did in self.dandisets:
+                    yield await self.client.get_dandiset(did)
+            else:
+                async with aclosing(self.client.get_dandisets()) as ait:
+                    async for info in ait:
+                        log.info("Found Dandiset %s", info.identifier)
+                        yield info
 
-    def make_dandiset(self, info: DandisetInfo) -> Dandiset:
-        return Dandiset(
-            identifier=info.identifier,
-            draft_modified=info.draft_modified,
-            path=self.mount_point / "dandisets" / info.identifier / "draft",
-            reportdir=self.reports_root / "results" / info.identifier,
-            versions=self.versions,
-        )
+        async with aclosing(inner()) as ait:
+            async for info in ait:
+                yield DandisetTester(
+                    reporter=DandisetReporter(
+                        identifier=info.identifier,
+                        draft_modified=info.draft_modified,
+                        reportdir=self.reports_root / "results" / info.identifier,
+                        versions=self.versions,
+                    ),
+                    mount_path=(
+                        self.mount_point / "dandisets" / info.identifier / "draft"
+                    ),
+                    client=self.client,
+                )
 
 
 @dataclass
-class Dandiset:
-    identifier: str
-    draft_modified: datetime
-    path: Path
-    reportdir: Path
-    versions: dict[str, str]
+class DandisetTester:
+    reporter: DandisetReporter
+    mount_path: Path
+    client: AsyncDandiClient
 
     @property
-    def statusfile(self) -> Path:
-        return self.reportdir / "status.yaml"
+    def identifier(self) -> str:
+        return self.reporter.identifier
 
-    def load_status(self) -> DandisetStatus:
-        return DandisetStatus.from_file(self.identifier, self.statusfile)
-
-    def dump_status(self, status: DandisetStatus) -> None:
-        self.statusfile.parent.mkdir(parents=True, exist_ok=True)
-        status.to_file(self.statusfile)
-
-    async def test_all_assets(self) -> DandisetReport:
+    async def test_all_assets(self) -> None:
         log.info("Processing Dandiset %s", self.identifier)
-        report = DandisetReport(dandiset=self)
+        with self.reporter.session() as report:
 
-        async def dowork(job: TestCase | Untested) -> None:
-            res = await job.run()
-            if isinstance(res, AssetTestResult):
-                report.register_test_result(res)
-            else:
-                assert isinstance(res, UntestedAsset)
-                report.register_untested(res)
-
-        async def aiterassets() -> AsyncGenerator[TestCase | Untested, None]:
-            async for asset in self.aiterassets():
-                log.info(
-                    "Dandiset %s: found asset %s", self.identifier, asset.asset_path
-                )
-                report.nassets += 1
-                if asset.is_nwb():
-                    for t in TESTS:
-                        yield TestCase(
-                            asset=asset, testfunc=t, dandiset_id=self.identifier
-                        )
+            async def dowork(job: TestCase | Untested) -> None:
+                res = await job.run()
+                if isinstance(res, AssetTestResult):
+                    report.register_test_result(res)
                 else:
-                    yield Untested(asset=asset, dandiset_id=self.identifier)
+                    assert isinstance(res, UntestedAsset)
+                    report.register_untested(res)
 
-        await pool_tasks(dowork, aiterassets(), WORKERS_PER_DANDISET)
-        report.finished()
-        return report
+            async def aitercases() -> AsyncGenerator[TestCase | Untested, None]:
+                async for asset in self.aiterassets():
+                    log.info(
+                        "Dandiset %s: found asset %s", self.identifier, asset.asset_path
+                    )
+                    if asset.is_nwb():
+                        for t in TESTS:
+                            yield TestCase(
+                                asset=asset, testfunc=t, dandiset_id=self.identifier
+                            )
+                    else:
+                        yield Untested(asset=asset, dandiset_id=self.identifier)
 
-    async def test_random_asset(self) -> Optional[AssetReport]:
+            await pool_tasks(dowork, aitercases(), WORKERS_PER_DANDISET)
+
+    async def test_random_asset(self) -> bool:
+        # Returns True if anything tested
         log.info("Scanning Dandiset %s", self.identifier)
         all_assets = [asset async for asset in self.aiterassets()]
         all_nwbs = [asset for asset in all_assets if asset.is_nwb()]
         if all_nwbs:
-            report = await self.test_one_asset(choice(all_nwbs))
-            report.set_asset_paths({asset.asset_path for asset in all_assets})
-            return report
+            await self.test_one_asset(choice(all_nwbs))
+            self.reporter.set_asset_paths({asset.asset_path for asset in all_assets})
+            return True
         else:
             log.info("Dandiset %s: no NWB assets", self.identifier)
-            return None
+            return False
 
-    async def test_random_outdated_asset_first(self) -> Optional[AssetReport]:
-        try:
-            status = self.load_status()
-        except FileNotFoundError:
-            asset_paths = set()
-        else:
-            asset_paths = {
-                path for t in status.tests for path in t.outdated_assets(self.versions)
-            }
-        if asset_paths:
-            p = choice(list(asset_paths))
-            asset = Asset(filepath=self.path / p, asset_path=p)
-            report = await self.test_one_asset(asset)
-            report.set_asset_paths(
+    async def test_random_outdated_asset_first(self) -> bool:
+        # Returns True if anything tested
+        if outdated := self.reporter.outdated_assets():
+            p = choice(list(outdated))
+            asset = Asset(filepath=self.mount_path / p, asset_path=p)
+            await self.test_one_asset(asset)
+            self.reporter.set_asset_paths(
                 {asset.asset_path async for asset in self.aiterassets()}
             )
-            return report
+            return True
         else:
             log.info(
                 "Dandiset %s: no outdated assets in status.yaml; selecting from"
@@ -220,60 +211,147 @@ class Dandiset:
             )
             return await self.test_random_asset()
 
-    async def test_one_asset(self, asset: Asset) -> AssetReport:
-        report = AssetReport(dandiset=self)
-
+    async def test_one_asset(self, asset: Asset) -> None:
         async def dowork(job: TestCase) -> None:
-            report.register_test_result(await job.run())
+            self.reporter.register_test_result(await job.run())
 
         async def aiterjobs() -> AsyncGenerator[TestCase, None]:
             for t in TESTS:
                 yield TestCase(asset=asset, testfunc=t, dandiset_id=self.identifier)
 
         await pool_tasks(dowork, aiterjobs(), WORKERS_PER_DANDISET)
-        return report
 
     async def aiterassets(self) -> AsyncGenerator[Asset, None]:
-        async with aclosing(
-            self.healthstatus.client.get_asset_paths(self.identifier)
-        ) as ait:
+        async with aclosing(self.client.get_asset_paths(self.identifier)) as ait:
             async for path in ait:
                 yield Asset(
-                    filepath=self.path / path,
+                    filepath=self.mount_path / path,
                     asset_path=AssetPath(path),
                 )
 
 
 @dataclass
-class DandisetReport:
-    dandiset: Dandiset
-    nassets: int = 0
-    tests: dict[str, TestReport] = field(
-        default_factory=lambda: defaultdict(TestReport)
-    )
-    untested: list[UntestedAsset] = field(default_factory=list)
-    started: datetime = field(default_factory=lambda: datetime.now().astimezone())
-    ended: Optional[datetime] = None
+class DandisetReporter:
+    identifier: str
+    draft_modified: datetime
+    reportdir: Path
+    versions: dict[str, str]
+    status: DandisetStatus = field(init=False)
+    errors: list[TestError] = field(init=False, default_factory=list)
+    started: datetime = field(init=False, default_factory=nowstamp)
+
+    def __post_init__(self) -> None:
+        try:
+            self.status = DandisetStatus.from_file(self.identifier, self.statusfile)
+        except FileNotFoundError:
+            self.status = DandisetStatus(
+                dandiset=self.identifier,
+                draft_modified=self.draft_modified,
+                tests=[TestStatus(name=testname) for testname in TESTS.keys()],
+                versions=self.versions,
+            )
+
+    @property
+    def statusfile(self) -> Path:
+        return self.reportdir / "status.yaml"
+
+    def dump(self) -> None:
+        self.status.to_file(self.statusfile)
+        errors_by_test = defaultdict(list)
+        for e in self.errors:
+            errors_by_test[e.testname].append(e)
+        for testname, errors in errors_by_test.items():
+            with (
+                self.reportdir
+                / f"{self.started:%Y.%m.%d.%H.%M.%S}_{testname}_errors.log"
+            ).open("w", encoding="utf-8", errors="surrogateescape") as fp:
+                for e in errors:
+                    print(
+                        f"Asset: {e.asset}\nOutput:\n"
+                        + textwrap.indent(e.output, " " * 4),
+                        file=fp,
+                    )
+
+    def outdated_assets(self) -> set[AssetPath]:
+        return {
+            path for t in self.status.tests for path in t.outdated_assets(self.versions)
+        }
+
+    def session(self) -> DandisetSession:
+        return DandisetSession(self)
 
     def register_test_result(self, r: AssetTestResult) -> None:
-        self.tests[r.testname].by_outcome[r.outcome].append(r)
+        self.status.update_asset(r, self.versions)
+        if r.outcome is Outcome.FAIL:
+            assert r.output is not None
+            self.errors.append(
+                TestError(
+                    testname=r.testname,
+                    asset=r.asset_path,
+                    output=r.output,
+                )
+            )
+
+    def set_asset_paths(self, paths: set[AssetPath]) -> None:
+        self.status.retain(paths, self.versions)
+
+
+@dataclass
+class DandisetSession:
+    reporter: DandisetReporter
+    tests: dict[str, TestReport] = field(
+        init=False, default_factory=lambda: defaultdict(TestReport)
+    )
+    untested: list[UntestedAsset] = field(init=False, default_factory=list)
+    errors: list[TestError] = field(init=False, default_factory=list)
+    ended: Optional[datetime] = field(init=False, default=None)
+
+    def __enter__(self) -> DandisetSession:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        _exc_val: BaseException | None,
+        _exc_tb: TracebackType | None,
+    ) -> None:
+        if exc_type is None:
+            self.ended = datetime.now().astimezone()
+            self.reporter.status = self.as_status()
+            self.reporter.errors = self.errors
+
+    def register_test_result(self, r: AssetTestResult) -> None:
+        self.tests[r.testname].register(r)
+        if r.outcome is Outcome.FAIL:
+            assert r.output is not None
+            self.errors.append(
+                TestError(
+                    testname=r.testname,
+                    asset=r.asset_path,
+                    output=r.output,
+                )
+            )
 
     def register_untested(self, d: UntestedAsset) -> None:
         self.untested.append(d)
 
-    def finished(self) -> None:
-        self.ended = datetime.now().astimezone()
+    @property
+    def nassets(self) -> int:
+        return len(
+            {p for report in self.tests.values() for p in report.asset_paths()}
+            | {ua.asset for ua in self.untested}
+        )
 
     def as_status(self) -> DandisetStatus:
         assert self.ended is not None
         return DandisetStatus(
-            dandiset=self.dandiset.identifier,
-            draft_modified=self.dandiset.draft_modified,
-            last_run=self.started,
+            dandiset=self.reporter.identifier,
+            draft_modified=self.reporter.draft_modified,
+            last_run=self.reporter.started,
             last_run_ended=self.ended,
-            last_run_duration=(self.ended - self.started).total_seconds(),
+            last_run_duration=(self.ended - self.reporter.started).total_seconds(),
             nassets=self.nassets,
-            versions=self.dandiset.versions,
+            versions=self.reporter.versions,
             tests=[
                 TestStatus(
                     name=name,
@@ -289,28 +367,15 @@ class DandisetReport:
             untested=self.untested,
         )
 
-    def dump(self) -> None:
-        self.dandiset.dump_status(self.as_status())
-        for testname, report in self.tests.items():
-            if report.failed:
-                with (
-                    self.dandiset.reportdir
-                    / f"{self.started:%Y.%m.%d.%H.%M.%S}_{testname}_errors.log"
-                ).open("w", encoding="utf-8", errors="surrogateescape") as fp:
-                    for r in report.failed:
-                        assert r.output is not None
-                        print(
-                            f"Asset: {r.asset_path}\nOutput:\n"
-                            + textwrap.indent(r.output, " " * 4),
-                            file=fp,
-                        )
-
 
 @dataclass
 class TestReport:
     by_outcome: dict[Outcome, list[AssetTestResult]] = field(
         init=False, default_factory=lambda: defaultdict(list)
     )
+
+    def register(self, r: AssetTestResult) -> None:
+        self.by_outcome[r.outcome].append(r)
 
     @property
     def passed(self) -> list[AssetTestResult]:
@@ -324,44 +389,12 @@ class TestReport:
     def timedout(self) -> list[AssetTestResult]:
         return self.by_outcome[Outcome.TIMEOUT]
 
+    def asset_paths(self) -> set[AssetPath]:
+        return {atr.asset_path for lst in self.by_outcome.values() for atr in lst}
+
 
 @dataclass
-class AssetReport:
-    dandiset: Dandiset
-    results: list[AssetTestResult] = field(default_factory=list)
-    started: datetime = field(default_factory=lambda: datetime.now().astimezone())
-    asset_paths: set[AssetPath] | None = None
-
-    def register_test_result(self, r: AssetTestResult) -> None:
-        self.results.append(r)
-
-    def set_asset_paths(self, paths: set[AssetPath]) -> None:
-        self.asset_paths = paths
-
-    def dump(self) -> None:
-        try:
-            status = self.dandiset.load_status()
-        except FileNotFoundError:
-            status = DandisetStatus(
-                dandiset=self.dandiset.identifier,
-                draft_modified=self.dandiset.draft_modified,
-                tests=[TestStatus(name=testname) for testname in TESTS.keys()],
-                versions=self.dandiset.versions,
-            )
-        for r in self.results:
-            status.update_asset(r, self.dandiset.versions)
-        if self.asset_paths is not None:
-            status.retain(self.asset_paths, self.dandiset.versions)
-        self.dandiset.dump_status(status)
-        for r in self.results:
-            if r.outcome is Outcome.FAIL:
-                with (
-                    self.dandiset.reportdir
-                    / f"{self.started:%Y.%m.%d.%H.%M.%S}_{r.testname}_errors.log"
-                ).open("a", encoding="utf-8", errors="surrogateescape") as fp:
-                    assert r.output is not None
-                    print(
-                        f"Asset: {r.asset_path}\nOutput:\n"
-                        + textwrap.indent(r.output, " " * 4),
-                        file=fp,
-                    )
+class TestError:
+    testname: str
+    asset: AssetPath
+    output: str

--- a/code/src/healthstatus/checker.py
+++ b/code/src/healthstatus/checker.py
@@ -198,7 +198,9 @@ class DandisetTester:
         # Returns True if anything tested
         all_assets = [asset async for asset in self.aiterassets()]
         all_asset_paths = {asset.asset_path for asset in all_assets}
-        if outdated := (self.reporter.outdated_assets() & all_asset_paths):
+        if outdated := (self.reporter.outdated_assets() & all_asset_paths) | (
+            all_asset_paths - self.reporter.all_assets()
+        ):
             p = choice(list(outdated))
             asset = Asset(filepath=self.mount_path / p, asset_path=p)
             await self.test_one_asset(asset)
@@ -274,6 +276,9 @@ class DandisetReporter:
                         + textwrap.indent(e.output, " " * 4),
                         file=fp,
                     )
+
+    def all_assets(self) -> set[AssetPath]:
+        return {path for t in self.status.tests for path in t.all_assets()}
 
     def outdated_assets(self) -> set[AssetPath]:
         return {

--- a/code/src/healthstatus/checker.py
+++ b/code/src/healthstatus/checker.py
@@ -198,11 +198,16 @@ class DandisetTester:
         # Returns True if anything tested
         all_assets = [asset async for asset in self.aiterassets()]
         all_asset_paths = {asset.asset_path for asset in all_assets}
-        if outdated := (self.reporter.outdated_assets() & all_asset_paths) | (
+        outdated_paths = (self.reporter.outdated_assets() & all_asset_paths) | (
             all_asset_paths - self.reporter.all_assets()
-        ):
-            p = choice(list(outdated))
-            asset = Asset(filepath=self.mount_path / p, asset_path=p)
+        )
+        outdated = [
+            asset
+            for p in outdated_paths
+            if (asset := Asset(filepath=self.mount_path / p, asset_path=p)).is_nwb()
+        ]
+        if outdated:
+            asset = choice(outdated)
             await self.test_one_asset(asset)
             self.reporter.set_asset_paths(all_asset_paths)
             return True

--- a/code/src/healthstatus/config.py
+++ b/code/src/healthstatus/config.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+DANDI_API_URL = "https://api.dandiarchive.org/api"
+
 MATNWB_INSTALL_DIR = Path("matnwb")  # in current working directory
 
 PACKAGES_TO_VERSION = ["pynwb", "hdmf"]

--- a/code/src/healthstatus/core.py
+++ b/code/src/healthstatus/core.py
@@ -29,7 +29,7 @@ class TestResult:
     elapsed: float | None = None  # Only set if outcome is PASS
 
 
-@dataclass
+@dataclass(frozen=True)
 class Asset:
     filepath: Path
     asset_path: AssetPath

--- a/code/src/healthstatus/core.py
+++ b/code/src/healthstatus/core.py
@@ -175,9 +175,9 @@ class DandisetStatus(BaseModel):
             return value
 
     @classmethod
-    def from_file(cls, dandiset: str, yamlfile: Path) -> DandisetStatus:
+    def from_file(cls, yamlfile: Path) -> DandisetStatus:
         with yamlfile.open() as fp:
-            return cls.model_validate({"dandiset": dandiset, **load_yaml_lineno(fp)})
+            return cls.model_validate(load_yaml_lineno(fp))
 
     def to_file(self, path: Path) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/code/src/healthstatus/core.py
+++ b/code/src/healthstatus/core.py
@@ -144,7 +144,7 @@ class TestStatus(BaseModel):
 
 
 class UntestedAsset(BaseModel):
-    asset: str
+    asset: AssetPath
     size: int
     file_type: str
     mime_type: str
@@ -180,6 +180,7 @@ class DandisetStatus(BaseModel):
             return cls.model_validate({"dandiset": dandiset, **load_yaml_lineno(fp)})
 
     def to_file(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
         jsonable = self.model_dump(mode="json")
         path.write_text(yaml.dump(jsonable))
 
@@ -206,6 +207,7 @@ class DandisetStatus(BaseModel):
             t.assets_timeout = [
                 a for a in t.assets_timeout if getpath(a) in asset_paths
             ]
+        self.nassets = len(asset_paths)
         self.prune_versions(current_versions)
 
     def prune_versions(self, current_versions: dict[str, str]) -> None:

--- a/code/src/healthstatus/core.py
+++ b/code/src/healthstatus/core.py
@@ -90,6 +90,10 @@ class TestStatus(BaseModel):
         for asset in self.assets_timeout:
             yield (getpath(asset), Outcome.TIMEOUT)
 
+    def all_assets(self) -> Iterator[AssetPath]:
+        for asset in [*self.assets_ok, *self.assets_nok, *self.assets_timeout]:
+            yield getpath(asset)
+
     def outdated_assets(self, current_versions: dict[str, str]) -> Iterator[AssetPath]:
         for asset in [*self.assets_ok, *self.assets_nok, *self.assets_timeout]:
             if getversions(asset) != current_versions:

--- a/code/src/healthstatus/util.py
+++ b/code/src/healthstatus/util.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 import subprocess
 import requests
@@ -71,3 +72,7 @@ class MatNWBInstaller:
             text=True,
             check=True,
         ).stdout.strip()
+
+
+def nowstamp() -> datetime:
+    return datetime.now().astimezone()

--- a/code/test/data/report-input/000001/status.yaml
+++ b/code/test/data/report-input/000001/status.yaml
@@ -1,3 +1,4 @@
+dandiset: '000001'
 dandiset_version: 9c6ab8750946cdac16c62057ec1f76f9ce954fe1
 last_run: 2022-12-15 10:59:47.526056-05:00
 nassets: 5

--- a/code/test/data/report-input/000002/status.yaml
+++ b/code/test/data/report-input/000002/status.yaml
@@ -1,3 +1,4 @@
+dandiset: '000002'
 dandiset_version: 9c6ab8750946cdac16c62057ec1f76f9ce954fe1
 last_run: 2022-12-15 10:59:47.526056-05:00
 nassets: 3

--- a/code/test/data/report-input/000003/status.yaml
+++ b/code/test/data/report-input/000003/status.yaml
@@ -1,3 +1,4 @@
+dandiset: '000003'
 dandiset_version: 9c6ab8750946cdac16c62057ec1f76f9ce954fe1
 last_run: 2022-12-15 10:59:47.526056-05:00
 nassets: 3

--- a/code/test/data/report-input/000004/status.yaml
+++ b/code/test/data/report-input/000004/status.yaml
@@ -1,3 +1,4 @@
+dandiset: '000004'
 dandiset_version: 9c6ab8750946cdac16c62057ec1f76f9ce954fe1
 last_run: 2022-12-15 10:59:47.526056-05:00
 nassets: 3

--- a/code/test/data/report-input/000005/status.yaml
+++ b/code/test/data/report-input/000005/status.yaml
@@ -1,3 +1,4 @@
+dandiset: '000005'
 dandiset_version: 9c6ab8750946cdac16c62057ec1f76f9ce954fe1
 last_run: 2022-12-15 10:59:47.526056-05:00
 nassets: 3

--- a/code/test/data/report-input/000006/status.yaml
+++ b/code/test/data/report-input/000006/status.yaml
@@ -1,3 +1,4 @@
+dandiset: '000006'
 dandiset_version: 9c6ab8750946cdac16c62057ec1f76f9ce954fe1
 last_run: 2022-12-15 10:59:47.526056-05:00
 nassets: 0

--- a/code/test/data/report-output.md
+++ b/code/test/data/report-output.md
@@ -12,9 +12,9 @@
 # By Dandiset
 | Dandiset | pynwb_open_load_ns | matnwb_nwbRead | Untested |
 | --- | --- | --- | --- |
-| [000001](results/000001/status.yaml) | [3 passed](results/000001/status.yaml#L6), 0 failed, 0 timed out | [3 passed](results/000001/status.yaml#L13), 0 failed, 0 timed out | [2](results/000001/status.yaml#L19) |
-| [000002](results/000002/status.yaml) | 0 passed, [3 failed](results/000002/status.yaml#L5), 0 timed out | 0 passed, [3 failed](results/000002/status.yaml#L12), 0 timed out | — |
-| [000003](results/000003/status.yaml) | 0 passed, 0 failed, [3 timed out](results/000003/status.yaml#L7) | 0 passed, 0 failed, [3 timed out](results/000003/status.yaml#L14) | — |
-| [000004](results/000004/status.yaml) | [3 passed](results/000004/status.yaml#L6), 0 failed, 0 timed out | 0 passed, [3 failed](results/000004/status.yaml#L12), 0 timed out | — |
-| [000005](results/000005/status.yaml) | [3 passed](results/000005/status.yaml#L6), 0 failed, 0 timed out | [1 passed](results/000005/status.yaml#L14), [1 failed](results/000005/status.yaml#L12), [1 timed out](results/000005/status.yaml#L16) | — |
+| [000001](results/000001/status.yaml) | [3 passed](results/000001/status.yaml#L7), 0 failed, 0 timed out | [3 passed](results/000001/status.yaml#L14), 0 failed, 0 timed out | [2](results/000001/status.yaml#L20) |
+| [000002](results/000002/status.yaml) | 0 passed, [3 failed](results/000002/status.yaml#L6), 0 timed out | 0 passed, [3 failed](results/000002/status.yaml#L13), 0 timed out | — |
+| [000003](results/000003/status.yaml) | 0 passed, 0 failed, [3 timed out](results/000003/status.yaml#L8) | 0 passed, 0 failed, [3 timed out](results/000003/status.yaml#L15) | — |
+| [000004](results/000004/status.yaml) | [3 passed](results/000004/status.yaml#L7), 0 failed, 0 timed out | 0 passed, [3 failed](results/000004/status.yaml#L13), 0 timed out | — |
+| [000005](results/000005/status.yaml) | [3 passed](results/000005/status.yaml#L7), 0 failed, 0 timed out | [1 passed](results/000005/status.yaml#L15), [1 failed](results/000005/status.yaml#L13), [1 timed out](results/000005/status.yaml#L17) | — |
 | [000006](results/000006/status.yaml) | — | — | — |


### PR DESCRIPTION
This PR builds on top of #81.

Currently, the `random-outdated-asset-first` mode does not consider assets that exist on the Archive but not in `status.yaml` (except in the case where all assets in `status.yaml` were tested with the latest software versions), and it also does not limit the candidate assets to NWBs.  This PR fixes both of those things.