### PR TITLE
Add "test" and "status" to asset entries in `status.yaml` files

### DIFF
--- a/code/test/data/report-input/000001/status.yaml
+++ b/code/test/data/report-input/000001/status.yaml
@@ -5,27 +5,41 @@ nassets: 5
 tests:
 - assets_nok: []
   assets_ok:
-  - asset01.nwb
-  - asset02.nwb
-  - asset03.nwb
+  - path: asset01.nwb
+    status: pass
+    test: pynwb_open_load_ns
+  - path: asset02.nwb
+    status: pass
+    test: pynwb_open_load_ns
+  - path: asset03.nwb
+    status: pass
+    test: pynwb_open_load_ns
   assets_timeout: []
   name: pynwb_open_load_ns
 - assets_nok: []
   assets_ok:
-  - asset01.nwb
-  - asset02.nwb
-  - asset03.nwb
+  - path: asset01.nwb
+    status: pass
+    test: matnwb_nwbRead
+  - path: asset02.nwb
+    status: pass
+    test: matnwb_nwbRead
+  - path: asset03.nwb
+    status: pass
+    test: matnwb_nwbRead
   assets_timeout: []
   name: matnwb_nwbRead
 untested:
-  - asset: asset04.json
-    size: 501
-    file_type: JSON data
-    mime_type: application/json
-  - asset: asset05.txt
-    size: 1025
-    file_type: ASCII text
-    mime_type: text/plain
+- asset: asset04.json
+  file_type: JSON data
+  mime_type: application/json
+  size: 501
+  status: untested
+- asset: asset05.txt
+  file_type: ASCII text
+  mime_type: text/plain
+  size: 1025
+  status: untested
 versions:
   hdmf: 3.4.7
   matnwb: v2.5.0.0

--- a/code/test/data/report-input/000002/status.yaml
+++ b/code/test/data/report-input/000002/status.yaml
@@ -4,16 +4,28 @@ last_run: 2022-12-15 10:59:47.526056-05:00
 nassets: 3
 tests:
 - assets_nok:
-  - asset01.nwb
-  - asset02.nwb
-  - asset03.nwb
+  - path: asset01.nwb
+    status: fail
+    test: pynwb_open_load_ns
+  - path: asset02.nwb
+    status: fail
+    test: pynwb_open_load_ns
+  - path: asset03.nwb
+    status: fail
+    test: pynwb_open_load_ns
   assets_ok: []
   assets_timeout: []
   name: pynwb_open_load_ns
 - assets_nok:
-  - asset01.nwb
-  - asset02.nwb
-  - asset03.nwb
+  - path: asset01.nwb
+    status: fail
+    test: matnwb_nwbRead
+  - path: asset02.nwb
+    status: fail
+    test: matnwb_nwbRead
+  - path: asset03.nwb
+    status: fail
+    test: matnwb_nwbRead
   assets_ok: []
   assets_timeout: []
   name: matnwb_nwbRead

--- a/code/test/data/report-input/000003/status.yaml
+++ b/code/test/data/report-input/000003/status.yaml
@@ -6,16 +6,28 @@ tests:
 - assets_nok: []
   assets_ok: []
   assets_timeout:
-  - asset01.nwb
-  - asset02.nwb
-  - asset03.nwb
+  - path: asset01.nwb
+    status: timeout
+    test: pynwb_open_load_ns
+  - path: asset02.nwb
+    status: timeout
+    test: pynwb_open_load_ns
+  - path: asset03.nwb
+    status: timeout
+    test: pynwb_open_load_ns
   name: pynwb_open_load_ns
 - assets_nok: []
   assets_ok: []
   assets_timeout:
-  - asset01.nwb
-  - asset02.nwb
-  - asset03.nwb
+  - path: asset01.nwb
+    status: timeout
+    test: matnwb_nwbRead
+  - path: asset02.nwb
+    status: timeout
+    test: matnwb_nwbRead
+  - path: asset03.nwb
+    status: timeout
+    test: matnwb_nwbRead
   name: matnwb_nwbRead
 versions:
   hdmf: 3.4.7

--- a/code/test/data/report-input/000004/status.yaml
+++ b/code/test/data/report-input/000004/status.yaml
@@ -5,15 +5,27 @@ nassets: 3
 tests:
 - assets_nok: []
   assets_ok:
-  - asset01.nwb
-  - asset02.nwb
-  - asset03.nwb
+  - path: asset01.nwb
+    status: pass
+    test: pynwb_open_load_ns
+  - path: asset02.nwb
+    status: pass
+    test: pynwb_open_load_ns
+  - path: asset03.nwb
+    status: pass
+    test: pynwb_open_load_ns
   assets_timeout: []
   name: pynwb_open_load_ns
 - assets_nok:
-  - asset01.nwb
-  - asset02.nwb
-  - asset03.nwb
+  - path: asset01.nwb
+    status: fail
+    test: matnwb_nwbRead
+  - path: asset02.nwb
+    status: fail
+    test: matnwb_nwbRead
+  - path: asset03.nwb
+    status: fail
+    test: matnwb_nwbRead
   assets_ok: []
   assets_timeout: []
   name: matnwb_nwbRead

--- a/code/test/data/report-input/000005/status.yaml
+++ b/code/test/data/report-input/000005/status.yaml
@@ -5,17 +5,29 @@ nassets: 3
 tests:
 - assets_nok: []
   assets_ok:
-  - asset01.nwb
-  - asset02.nwb
-  - asset03.nwb
+  - path: asset01.nwb
+    status: pass
+    test: pynwb_open_load_ns
+  - path: asset02.nwb
+    status: pass
+    test: pynwb_open_load_ns
+  - path: asset03.nwb
+    status: pass
+    test: pynwb_open_load_ns
   assets_timeout: []
   name: pynwb_open_load_ns
 - assets_nok:
-  - asset02.nwb
+  - path: asset02.nwb
+    status: fail
+    test: matnwb_nwbRead
   assets_ok:
-  - asset01.nwb
+  - path: asset01.nwb
+    status: pass
+    test: matnwb_nwbRead
   assets_timeout:
-  - asset03.nwb
+  - path: asset03.nwb
+    status: timeout
+    test: matnwb_nwbRead
   name: matnwb_nwbRead
 versions:
   hdmf: 3.4.7

--- a/code/test/data/report-output.md
+++ b/code/test/data/report-output.md
@@ -12,9 +12,9 @@
 # By Dandiset
 | Dandiset | pynwb_open_load_ns | matnwb_nwbRead | Untested |
 | --- | --- | --- | --- |
-| [000001](results/000001/status.yaml) | [3 passed](results/000001/status.yaml#L7), 0 failed, 0 timed out | [3 passed](results/000001/status.yaml#L14), 0 failed, 0 timed out | [2](results/000001/status.yaml#L20) |
-| [000002](results/000002/status.yaml) | 0 passed, [3 failed](results/000002/status.yaml#L6), 0 timed out | 0 passed, [3 failed](results/000002/status.yaml#L13), 0 timed out | — |
-| [000003](results/000003/status.yaml) | 0 passed, 0 failed, [3 timed out](results/000003/status.yaml#L8) | 0 passed, 0 failed, [3 timed out](results/000003/status.yaml#L15) | — |
-| [000004](results/000004/status.yaml) | [3 passed](results/000004/status.yaml#L7), 0 failed, 0 timed out | 0 passed, [3 failed](results/000004/status.yaml#L13), 0 timed out | — |
-| [000005](results/000005/status.yaml) | [3 passed](results/000005/status.yaml#L7), 0 failed, 0 timed out | [1 passed](results/000005/status.yaml#L15), [1 failed](results/000005/status.yaml#L13), [1 timed out](results/000005/status.yaml#L17) | — |
+| [000001](results/000001/status.yaml) | [3 passed](results/000001/status.yaml#L7), 0 failed, 0 timed out | [3 passed](results/000001/status.yaml#L20), 0 failed, 0 timed out | [2](results/000001/status.yaml#L32) |
+| [000002](results/000002/status.yaml) | 0 passed, [3 failed](results/000002/status.yaml#L6), 0 timed out | 0 passed, [3 failed](results/000002/status.yaml#L19), 0 timed out | — |
+| [000003](results/000003/status.yaml) | 0 passed, 0 failed, [3 timed out](results/000003/status.yaml#L8) | 0 passed, 0 failed, [3 timed out](results/000003/status.yaml#L21) | — |
+| [000004](results/000004/status.yaml) | [3 passed](results/000004/status.yaml#L7), 0 failed, 0 timed out | 0 passed, [3 failed](results/000004/status.yaml#L19), 0 timed out | — |
+| [000005](results/000005/status.yaml) | [3 passed](results/000005/status.yaml#L7), 0 failed, 0 timed out | [1 passed](results/000005/status.yaml#L23), [1 failed](results/000005/status.yaml#L19), [1 timed out](results/000005/status.yaml#L27) | — |
 | [000006](results/000006/status.yaml) | — | — | — |

--- a/tools/migrations/gh-86.py
+++ b/tools/migrations/gh-86.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env pipx run
+# /// script
+# requires-python = ">=3.8"
+# dependencies = ["PyYAML"]
+# ///
+
+from __future__ import annotations
+from pathlib import Path
+import re
+import sys
+import yaml
+
+
+def main() -> None:
+    resultsdir = Path(sys.argv[1])
+    for p in resultsdir.iterdir():
+        if p.is_dir() and re.fullmatch(r"[0-9]{6}", p.name):
+            statusfile = p / "status.yaml"
+            with statusfile.open() as fp:
+                data = yaml.safe_load(fp)
+            for t in data["tests"]:
+                testname = t["name"]
+                for listfield, status in [
+                    ("assets_nok", "fail"),
+                    ("assets_ok", "pass"),
+                    ("assets_timeout", "timeout"),
+                ]:
+                    newlist = []
+                    for entry in t[listfield]:
+                        if isinstance(entry, str):
+                            newlist.append(
+                                {
+                                    "path": entry,
+                                    "test": testname,
+                                    "status": status,
+                                }
+                            )
+                        else:
+                            newlist.append(
+                                {
+                                    "path": entry["path"],
+                                    "test": testname,
+                                    "status": status,
+                                    "versions": entry["versions"],
+                                }
+                            )
+                    t[listfield] = newlist
+            if "untested" in data:
+                for entry in data["untested"]:
+                    entry["status"] = "untested"
+            statusfile.write_text(yaml.dump(data))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #86.

Upon merging this PR, the `status.yaml` files need to be migrated as follows:

* Stop any running `dandiset-healthstatus` instances on drogon
* In an up-to-date clone of this repository, run `python3 tools/migrations/gh-86.py results/` (PyYAML required)
* Commit & push the changes
* Ensure the `dandisets-healthstatus` checkout on drogon is up to date before resuming the healthstatus processes